### PR TITLE
Display commits for github pushes

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -39,6 +39,9 @@ class Webhooks::GithubController < ApplicationController
     end
 
     msg = msg % [body['pusher']['name'], body['commits'].length, body['compare']]
+    body['commits'].each do |commit|
+      msg += "\n%s - %s" % [commit['id'][0..5], commit['message']]
+    end
     msg = repo_msg(body, msg)
 
     ChatService.new.send_update chat, msg

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -44,7 +44,7 @@ class Webhooks::GithubController < ApplicationController
     end
     msg = repo_msg(body, msg)
 
-    ChatService.new.send_update(chat, msg, true)
+    ChatService.new.send_update(chat, msg)
   end
 
   def issues_event(chat, body)

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -44,7 +44,7 @@ class Webhooks::GithubController < ApplicationController
     end
     msg = repo_msg(body, msg)
 
-    ChatService.new.send_update(chat, msg, false)
+    ChatService.new.send_update(chat, msg, true)
   end
 
   def issues_event(chat, body)

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -44,7 +44,7 @@ class Webhooks::GithubController < ApplicationController
     end
     msg = repo_msg(body, msg)
 
-    ChatService.new.send_update chat, msg
+    ChatService.new.send_update(chat, msg, false)
   end
 
   def issues_event(chat, body)

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -38,8 +38,8 @@ class ChatService
                                                                     host: Rails.configuration.web_app_hostname)
   end
 
-  def send_update(chat, msg, web_preview = true)
-    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: web_preview)
+  def send_update(chat, msg, disable_web_preview = false)
+    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: disable_web_preview)
 
     chat.increment_msgs_sent
   end

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -38,7 +38,7 @@ class ChatService
                                                                     host: Rails.configuration.web_app_hostname)
   end
 
-  def send_update(chat, msg, disable_web_preview = false)
+  def send_update(chat, msg, disable_web_preview = true)
     @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: disable_web_preview)
 
     chat.increment_msgs_sent

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -38,8 +38,8 @@ class ChatService
                                                                     host: Rails.configuration.web_app_hostname)
   end
 
-  def send_update(chat, msg)
-    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg)
+  def send_update(chat, msg, web_preview = true)
+    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: web_preview)
 
     chat.increment_msgs_sent
   end

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -38,8 +38,8 @@ class ChatService
                                                                     host: Rails.configuration.web_app_hostname)
   end
 
-  def send_update(chat, msg, disable_web_preview = true)
-    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: disable_web_preview)
+  def send_update(chat, msg, web_preview = false)
+    @telegram_api.sendMessage(chat_id: chat.telegram_chat_id, text: msg, disable_web_page_preview: !web_preview)
 
     chat.increment_msgs_sent
   end

--- a/spec/controllers/github_controller_spec.rb
+++ b/spec/controllers/github_controller_spec.rb
@@ -38,7 +38,7 @@ describe Webhooks::GithubController do
       body = load_file('github_controller_push_event.json')
 
       expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
-      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg, true)
+      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg)
 
       post :callback, body, chat_id: chat_id
 

--- a/spec/controllers/github_controller_spec.rb
+++ b/spec/controllers/github_controller_spec.rb
@@ -37,7 +37,7 @@ describe Webhooks::GithubController do
       request.headers['X-GitHub-Event'] = 'push'
       body = load_file('github_controller_push_event.json')
 
-      expected_msg = 'baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f'
+      expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
       allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg)
 
       post :callback, body, chat_id: chat_id

--- a/spec/controllers/github_controller_spec.rb
+++ b/spec/controllers/github_controller_spec.rb
@@ -38,7 +38,7 @@ describe Webhooks::GithubController do
       body = load_file('github_controller_push_event.json')
 
       expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
-      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg, false)
+      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg, true)
 
       post :callback, body, chat_id: chat_id
 

--- a/spec/controllers/github_controller_spec.rb
+++ b/spec/controllers/github_controller_spec.rb
@@ -38,7 +38,7 @@ describe Webhooks::GithubController do
       body = load_file('github_controller_push_event.json')
 
       expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
-      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg)
+      allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg, false)
 
       post :callback, body, chat_id: chat_id
 


### PR DESCRIPTION
As discussed in chat, this pull request improves the message for github pushes by listing the commit messages of all pushed commits. Additionally, it disables Telegrams web page parsing, which does nothing useful for the github compare url anyway.

The specs pass on my machine, but I'm unsure how to test the full stack.