### PR TITLE
Improve github push message

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -33,12 +33,14 @@ class Webhooks::GithubController < ApplicationController
 
   def push_event(chat, body)
     if body['commits'].length > 1
-      msg = '%s pushed %d commits %s'
+      msg = '%s pushed %d commits to %s %s'
     else
-      msg = '%s pushed %d commit %s'
+      msg = '%s pushed %d commit to %s %s'
     end
 
-    msg = msg % [body['pusher']['name'], body['commits'].length, body['compare']]
+    branch = body['ref'].split('/').last
+
+    msg = msg % [body['pusher']['name'], body['commits'].length, branch, body['compare']]
     body['commits'].each do |commit|
       msg += "\n%s - %s" % [commit['id'][0..5], commit['message']]
     end

--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -42,7 +42,8 @@ class Webhooks::GithubController < ApplicationController
 
     msg = msg % [body['pusher']['name'], body['commits'].length, branch, body['compare']]
     body['commits'].each do |commit|
-      msg += "\n%s - %s" % [commit['id'][0..5], commit['message']]
+      title = commit['message'].split("\n",2).first
+      msg += "\n%s - %s" % [commit['id'][0..5], title]
     end
     msg = repo_msg(body, msg)
 

--- a/spec/controllers/webhooks/github_controller_push_event.json
+++ b/spec/controllers/webhooks/github_controller_push_event.json
@@ -11,7 +11,7 @@
     {
       "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
       "distinct": true,
-      "message": "Update README.md",
+      "message": "Update README.md\n\nSome additional info\non multiple lines.",
       "timestamp": "2015-05-05T19:40:15-04:00",
       "url": "https://github.com/baxterthehacker/public-repo/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
       "author": {

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -39,7 +39,7 @@ describe Webhooks::GithubController do
       request.headers['X-GitHub-Event'] = 'push'
       body = load_file('github_controller_push_event.json')
 
-      expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
+      expected_msg = "baxterthehacker/public-repo: baxterthehacker pushed 1 commit to changes https://github.com/baxterthehacker/public-repo/compare/9049f1265b7d...0d1a26e67d8f\n0d1a26 - Update README.md"
       allow_any_instance_of(ChatService).to receive(:send_update).with(an_instance_of(Chat), expected_msg)
 
       post :callback, body, chat_id: chat_id


### PR DESCRIPTION
These commits show the name of the branch pushed to and limit the commit messages to the first line of the message.